### PR TITLE
Add dynamic dashboard contexts

### DIFF
--- a/ajax/refreshDashboard.php
+++ b/ajax/refreshDashboard.php
@@ -22,12 +22,13 @@
  */
 
 include ('../../../inc/includes.php');
+Html::header_nocache();
 
 Session::checkLoginUser();
 
-Html::header(PluginWebresourcesDashboard::getTypeName(Session::getPluralNumber()), '', 'plugins', 'PluginWebresourcesDashboard');
+if (!isset($_REQUEST['context'])) {
+   throw new RuntimeException('Required argument missing!');
+}
 
-$context = $_GET['context'] ?? 'personal';
-PluginWebresourcesDashboard::showDashboard($context);
-
-Html::footer();
+header('Content-Type', 'text/html');
+echo PluginWebresourcesDashboard::getDashboardContent($_REQUEST['context']);

--- a/inc/resource.class.php
+++ b/inc/resource.class.php
@@ -456,7 +456,7 @@ class PluginWebresourcesResource extends CommonDBVisible implements ExtraVisibil
       echo '<span class="very_small_space">'.__('Refresh icon image', 'webresources').'</span></div>';
       echo '<div class="webresources-item">';
       echo '<div class="webresources-item-icon">';
-      $icon_type = Toolbox::isValidWebUrl($this->fields['icon']) ? 'image' : 'icon';
+      $icon_type = PluginWebresourcesToolbox::isValidWebUrl($this->fields['icon']) ? 'image' : 'icon';
       echo '<img style="display:'.($icon_type === 'image' ? 'block' : 'none').'" src="' . $this->fields['icon'] . '" title="' . $this->fields['name'] . '" alt="' . $this->fields['name'] . '"/>';
       if (empty($this->fields['icon'])) {
          $this->fields['icon'] = 'fab fa-chrome';
@@ -473,7 +473,7 @@ class PluginWebresourcesResource extends CommonDBVisible implements ExtraVisibil
       $script = <<<JS
 $(document).ready(function() {
    function isWebURL(url) {
-      const pattern = /^(?:http[s]?:\/\/(?:[^\s`!()\[\]{};'",<>?«»“”‘’+]+|[^\s`!()\[\]{};:'".,<>?«»“”‘’+]))$/iu;
+      const pattern = /^(?:http[s]?:\/\/(?:[^\s`!()\[\]{};'",<>?«»“”‘’+]+|[^\s`!()\[\]{};:'".,<>«»“”‘’+]))$/iu;
       return pattern.test(url);
    }
 

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -21,13 +21,21 @@
  --------------------------------------------------------------------------
  */
 
-include ('../../../inc/includes.php');
+class PluginWebresourcesToolbox {
 
-Session::checkLoginUser();
-
-Html::header(PluginWebresourcesDashboard::getTypeName(Session::getPluralNumber()), '', 'plugins', 'PluginWebresourcesDashboard');
-
-$context = $_GET['context'] ?? 'personal';
-PluginWebresourcesDashboard::showDashboard($context);
-
-Html::footer();
+   /**
+    * Check URL validity
+    *
+    * Differs from {@link Toolbox::isValidWebUrl()} because this allows params in the URL
+    * @param string $url The URL to check
+    *
+    * @return boolean
+    */
+   public static function isValidWebUrl($url): bool {
+      $valid = preg_match(
+            "/^(?:http[s]?:\/\/(?:[^\s`!()\[\]{};'\",<>«»“”‘’+]+|[^\s`!()\[\]{};:'\".,<>«»“”‘’+]))$/iu",
+            $url
+         );
+      return $valid;
+   }
+}

--- a/setup.php
+++ b/setup.php
@@ -21,7 +21,7 @@
  --------------------------------------------------------------------------
  */
 
-define('PLUGIN_WEBRESOURCES_VERSION', '1.2.0');
+define('PLUGIN_WEBRESOURCES_VERSION', '1.3.0');
 define('PLUGIN_WEBRESOURCES_MIN_GLPI', '9.5.0');
 define('PLUGIN_WEBRESOURCES_MAX_GLPI', '9.6.0');
 


### PR DESCRIPTION
Adds contexts to the web resources dashboard:
 - [x] My Resources (Same as was shown before)
 - [x] Suppliers (If they have a website set)
 - [x] Entities (If they have a website set)
 - [x] Appliances/Web Apps

Original request asked for appliances as well, but I see no way to have a link to the appliance beyond external links. Core integration of web apps/appliances seems incomplete so I will refer to the plugin fields (Looks like the plugin was updated to 9.5 for that reason).
I also checked all other tables in a clean install with a URL or website column but found no further instances.

Closes #7 