### PR TITLE
Add menu location config option

### DIFF
--- a/front/dashboard.php
+++ b/front/dashboard.php
@@ -30,7 +30,8 @@ if (!$plugin->isActivated('webresources')) {
 
 Session::checkLoginUser();
 
-Html::header(PluginWebresourcesDashboard::getTypeName(Session::getPluralNumber()), '', 'plugins', 'PluginWebresourcesDashboard');
+$config = Config::getConfigurationValues('plugin:Webresources', ['menu']);
+Html::header(PluginWebresourcesDashboard::getTypeName(Session::getPluralNumber()), '', $config['menu'] ?? 'plugins', 'PluginWebresourcesDashboard');
 
 $context = $_GET['context'] ?? 'personal';
 PluginWebresourcesDashboard::showDashboard($context);

--- a/front/resource.form.php
+++ b/front/resource.form.php
@@ -106,7 +106,8 @@ if (isset($_POST["add"])) {
    Html::back();
 
 } else {
-   Html::header(PluginWebresourcesResource::getTypeName(Session::getPluralNumber()), '', 'plugins', 'PluginWebresourcesDashboard');
+   $config = Config::getConfigurationValues('plugin:Webresources', ['menu']);
+   Html::header(PluginWebresourcesResource::getTypeName(Session::getPluralNumber()), '', $config['menu'] ?? 'plugins', 'PluginWebresourcesDashboard');
    $resource->display($_REQUEST);
    Html::footer();
 }

--- a/front/resource.php
+++ b/front/resource.php
@@ -30,7 +30,8 @@ if (!$plugin->isActivated('webresources')) {
 
 Session::checkLoginUser();
 
-Html::header(PluginWebresourcesResource::getTypeName(Session::getPluralNumber()), '', 'plugins', 'PluginWebresourcesDashboard');
+$config = Config::getConfigurationValues('plugin:Webresources', ['menu']);
+Html::header(PluginWebresourcesResource::getTypeName(Session::getPluralNumber()), '', $config['menu'] ?? 'plugins', 'PluginWebresourcesDashboard');
 
 Search::show(PluginWebresourcesResource::class);
 

--- a/hook.php
+++ b/hook.php
@@ -113,6 +113,7 @@ function plugin_webresources_install()
    if (!count(Config::getConfigurationValues('plugin:Webresources'))) {
       Config::setConfigurationValues('plugin:Webresources', [
          'config_class'    => PluginWebresourcesConfig::class,
+         'menu'            => 'plugins',
          'use_duckduckgo'  => 0,
          'use_google'      => 0,
       ]);

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -46,16 +46,29 @@ class PluginWebresourcesConfig extends CommonDBTM
 
       echo "<form name='form' action=\"".Toolbox::getItemTypeFormURL('Config')."\" method='post'>";
       echo "<div class='center' id='tabsbody'>";
+
+      echo "<table class='tab_cadre_fixe'><thead>";
+      echo "<th colspan='4'>" . __('General Settings', 'webresources') . '</th></thead>';
+      echo '<td>' . __('Plugin Menu', 'webresources') . '</td>';
+      echo '<td>';
+      Dropdown::showFromArray('menu', [
+         'management'   => __('Management'),
+         'plugins'      => _n('Plugin', 'Plugins', Session::getPluralNumber()),
+         'tools'        => __('Tools'),
+      ], ['value' => $config['menu'] ?? 'plugins']);
+      echo '</td><td></td><td>';
+      echo '</td></tr></table>';
+
       echo "<table class='tab_cadre_fixe'><thead>";
       echo "<th colspan='4'>" . __('Favicon Settings', 'webresources') . '</th></thead>';
       echo '<td>' . __('Use DuckDuckGo Favicon Service', 'webresources') . '</td>';
       echo '<td>';
       echo "<input type='hidden' name='config_class' value='".__CLASS__."'>";
       echo "<input type='hidden' name='config_context' value='plugin:Webresources'>";
-      Dropdown::showYesNo('use_duckduckgo', $config['use_duckduckgo']);
+      Dropdown::showYesNo('use_duckduckgo', $config['use_duckduckgo'] ?? 0);
       echo '</td><td>' .__('Use Google Favicon Service', 'webresources'). '</td><td>';
-      Dropdown::showYesNo('use_google', $config['use_google']);
-      echo '</td></tr>';
+      Dropdown::showYesNo('use_google', $config['use_google'] ?? 0);
+      echo '</td></tr></table>';
 
       echo "<table class='tab_cadre_fixe'>";
       echo "<tr class='tab_bg_2'>";

--- a/setup.php
+++ b/setup.php
@@ -29,8 +29,9 @@ function plugin_init_webresources()
 {
 	global $PLUGIN_HOOKS;
 	$PLUGIN_HOOKS['csrf_compliant']['webresources'] = true;
+	$config = Config::getConfigurationValues('plugin:Webresources', ['menu']);
    if (Session::haveRight(PluginWebresourcesResource::$rightname, READ)) {
-      $PLUGIN_HOOKS['menu_toadd']['webresources'] = ['plugins' => 'PluginWebresourcesDashboard'];
+      $PLUGIN_HOOKS['menu_toadd']['webresources'] = [$config['menu'] ?? 'plugins' => 'PluginWebresourcesDashboard'];
    }
    Plugin::registerClass('PluginWebresourcesProfile', ['addtabon' => ['Profile']]);
    Plugin::registerClass('PluginWebresourcesConfig', ['addtabon' => 'Config']);


### PR DESCRIPTION
Add a config option to change which menu the Web Resources plugin pages show up under. Since the Plugins menu isn't really used by other plugins, user's may want to move the menu item to a different menu to avoid the addition of the Plugins menu for just this one plugin.

Added the possibility to have it under Management, Plugins, or Tools with Plugins remaining the default.