### PR TITLE
Add list view mode

### DIFF
--- a/ajax/refreshDashboard.php
+++ b/ajax/refreshDashboard.php
@@ -35,5 +35,21 @@ if (!isset($_REQUEST['context'])) {
    throw new RuntimeException('Required argument missing!');
 }
 
+if (empty($_REQUEST['context'])) {
+    $_REQUEST['context'] = 'personal';
+}
+if (!isset($_REQUEST['view_mode'])) {
+    $_REQUEST['view_mode'] = 'grid';
+}
+
 header('Content-Type', 'text/html');
-echo PluginWebresourcesDashboard::getDashboardContent($_REQUEST['context']);
+switch ($_REQUEST['view_mode']) {
+   case 'grid':
+      echo PluginWebresourcesDashboard::getDashboardContentGrid($_REQUEST['context']);
+      break;
+   case 'list':
+      echo PluginWebresourcesDashboard::getDashboardContentList($_REQUEST['context']);
+      break;
+   default:
+      throw new RuntimeException('Invalid view mode!');
+}

--- a/css/webresources.scss
+++ b/css/webresources.scss
@@ -19,7 +19,7 @@
  --------------------------------------------------------------------------
  */
 
-#page .webresources-toolbar {
+.webresources-toolbar {
    margin-bottom: 10px;
    font-size: 14px;
    padding: 10px;
@@ -46,60 +46,85 @@
    margin-bottom: 15px;
 }
 
-.webresources-categories {
-   .webresources-category {
-      border-top: 1px solid var(--tblr-body-color);
-      margin-bottom: 15px;
+#page .webresources-dashboard {
+   .webresources-categories {
+      .webresources-category {
+         border-top: 1px solid var(--tblr-body-color);
+         margin-bottom: 15px;
 
-      .webresources-category-header {
-         font-size: 1.2em;
-         border-top: 4px solid var(--tblr-body-color);
-         width: fit-content;
-         padding-right: 10px;
+         .webresources-category-header {
+            font-size: 1.2em;
+            border-top: 4px solid var(--tblr-body-color);
+            width: fit-content;
+            padding-right: 10px;
+         }
+      }
+   }
+}
+
+#page .webresources-dashboard[data-view-mode="grid"] {
+   .webresources-item {
+      display: inline-block;
+      margin-left: 15px;
+      margin-right: 10px;
+      width: 5em;
+      vertical-align: top;
+
+      a, a:hover {
+         color: var(--main-text-color);
+         text-decoration: none;
       }
 
-      .webresources-item {
-         display: inline-block;
-         margin-left: 15px;
-         margin-right: 10px;
-         width: 5em;
-         vertical-align: top;
+      &:hover {
+         background-color: var(--tblr-muted);
+         opacity: 0.6;
+      }
 
-         a, a:hover {
-            color: var(--main-text-color);
-            text-decoration: none;
+      .webresources-item-icon {
+         text-align: center;
+         font-size: 1.2em;
+         width: 74px;
+         height: 74px;
+         display: flex;
+         flex-direction: column;
+         justify-content: center;
+
+         img, i.fas, i.far, i.fab {
+            font-size: 64px;
+            width: 64px;
+            height: 64px;
+            margin-top: 5px;
+            margin-bottom: 5px;
+            padding-bottom: 3px;
          }
 
-         &:hover {
-            background-color: var(--tblr-muted);
-            opacity: 0.6;
+         img {
+            height: auto !important;
+         }
+      }
+
+      .webresources-item-title {
+         text-align: center;
+      }
+   }
+}
+
+#page .webresources-dashboard[data-view-mode="list"] {
+   table.table {
+      border-collapse: collapse;
+      tr {
+         vertical-align: middle;
+
+         td:first-of-type {
+            text-align: center;
+            width: 64px;
+            height: 64px;
          }
 
          .webresources-item-icon {
-            text-align: center;
-            font-size: 1.2em;
-            width: 74px;
-            height: 74px;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-
-            img, i.fas, i.far, i.fab {
-               font-size: 64px;
-               width: 64px;
-               height: 64px;
-               margin-top: 5px;
-               margin-bottom: 5px;
-               padding-bottom: 3px;
+            i.fas, i.far, i.fab {
+               font-size: 48px;
             }
-
-            img {
-               height: auto !important;
-            }
-         }
-
-         .webresources-item-title {
-            text-align: center;
          }
       }
    }

--- a/hook.php
+++ b/hook.php
@@ -173,7 +173,7 @@ function plugin_webresources_showPostItemForm(array $params)
       $ico = '';
       $color = '#000000';
       if (count($iterator)) {
-         $data = $iterator->next();
+         $data = $iterator->current();
          $ico = $data['icon'];
          $color = $data['color'];
       }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,0 +1,174 @@
+window.GlpiPluginWebResources = {
+   plugin_root_url: CFG_GLPI.root_doc + '/' + GLPI_PLUGINS_PATH.webresources,
+   manageUrl: (context, view_mode) => {
+      // if current base URL doesn't contain '/front/central.php'
+      if (window.location.href.indexOf('/front/central.php') === -1) {
+         const updateURLParameter = function(url, param, paramVal){
+            let newAdditionalURL = "";
+            let tempArray = url.split("?");
+            let baseURL = tempArray[0];
+            let additionalURL = tempArray[1];
+            let temp = "";
+            if (additionalURL) {
+               tempArray = additionalURL.split("&");
+               for (let i=0; i<tempArray.length; i++){
+                  if(tempArray[i].split('=')[0] != param){
+                     newAdditionalURL += temp + tempArray[i];
+                     temp = "&";
+                  }
+               }
+            }
+            const rows_txt = temp + "" + param + "=" + paramVal;
+            return baseURL + "?" + newAdditionalURL + rows_txt;
+         }
+         window.history.replaceState('', '', updateURLParameter(window.location.href, "context", context));
+         window.history.replaceState('', '', updateURLParameter(window.location.href, "view_mode", view_mode));
+      } else {
+         window.localStorage.setItem('webresources_central_state', JSON.stringify({
+            context: context,
+            view_mode: view_mode
+         }));
+      }
+   },
+   refreshDashboard: (context, view_mode) => {
+      const dashboard = $('.webresources-dashboard');
+      const view_switcher = $('.webresources-view-switcher');
+      // if context is not defined, replace context and view_mode with the ones from getDashboardState()
+      if (typeof context === 'undefined') {
+         const state = GlpiPluginWebResources.getDashboardState();
+         context = state.context;
+         view_mode = state.view_mode;
+      }
+
+      if (context.length === 0) {
+         context = 'personal';
+      }
+
+      $.ajax({
+         url: (window.GlpiPluginWebResources.plugin_root_url+"/ajax/refreshDashboard.php"),
+         data: {
+            context: context,
+            view_mode: view_mode
+         }
+      }).success(function(data) {
+         $("#webresources-content").empty();
+         $("#webresources-content").append(data);
+
+         // Update data attributes
+         dashboard.data('context', context);
+         dashboard.data('view-mode', view_mode);
+
+         // Update context dropdown value
+         $('.webresources-toolbar select[name="context"]').val(context).trigger('change.select2');
+
+         // Update view mode toggle button icon
+         if (view_mode === 'grid') {
+            view_switcher.find('i').attr('class', 'fas fa-list view-switcher');
+            view_switcher.find('i').attr('title', 'List view');
+         } else {
+            view_switcher.find('i').attr('class', 'fas fa-th view-switcher');
+            view_switcher.find('i').attr('title', 'Grid view');
+         }
+         window.GlpiPluginWebResources.manageUrl(context, view_mode);
+         window.GlpiPluginWebResources.applySearchFilters($('.webresources-toolbar input[name="search"]').get(0));
+      });
+   },
+   getDashboardState: () => {
+      if (window.location.href.indexOf('/front/central.php') === -1) {
+         const queryParams = new URLSearchParams(window.location.search);
+         return {
+            context: queryParams.get('context') || 'personal',
+            view_mode: queryParams.get('view_mode') || 'grid'
+         }
+      } else {
+         const ls_state = window.localStorage.getItem('webresources_central_state');
+         let state = {
+            context: 'personal',
+            view_mode: 'grid'
+         };
+         if (ls_state) {
+            return JSON.parse(ls_state);
+         } else {
+            return state;
+         }
+      }
+   },
+   registerListeners: () => {
+      const page = $('#page');
+
+      page.on('change', '.webresources-toolbar select[name="context"]', function(v) {
+         const new_context = v.target.value;
+         const dashboard = $('.webresources-dashboard');
+         const current_view_mode = dashboard.data('view-mode');
+         window.GlpiPluginWebResources.refreshDashboard(new_context, current_view_mode);
+      });
+
+      page.on('click', '.webresources-toolbar .webresources-view-mode', function() {
+         const dashboard = $('.webresources-dashboard');
+         const new_mode = dashboard.data('view-mode') === 'grid' ? 'list' : 'grid';
+         const current_context = dashboard.data('context');
+         window.GlpiPluginWebResources.refreshDashboard(current_context, new_mode);
+      });
+
+      page.on('keyup', '.webresources-toolbar input[name="search"]', function() {
+         window.GlpiPluginWebResources.applySearchFilters(this);
+      });
+   },
+   applySearchFilters: (search_el) => {
+      const items = $('.webresources-item');
+      const search_filter = search_el.value.toLowerCase();
+      if (search_filter.length > 0) {
+         items.each(function(i, v) {
+            if (v.textContent.toLowerCase().includes(search_filter)) {
+               $(v).show();
+            } else {
+               $(v).hide();
+            }
+         });
+      } else {
+         items.show();
+      }
+      const categories = $('.webresources-category');
+      categories.each(function(i, v) {
+         const cat = $(v);
+         if (cat.find('.webresources-item').filter(function(i2, f) {
+            return $(f).css('display') !== 'none';
+         }).length === 0) {
+            cat.hide();
+         } else {
+            cat.show();
+         }
+      });
+   },
+};
+
+$(document).ready(function() {
+   window.GlpiPluginWebResources.registerListeners();
+
+   // If dashboard element exists, refresh it. Otherwise, wait for it to be created
+   if ($('#webresources-content').length > 0) {
+      const state = window.GlpiPluginWebResources.getDashboardState();
+      window.GlpiPluginWebResources.refreshDashboard(state.context, state.view_mode);
+   } else {
+      // Use mutation observer to detect when dashboard element is created
+      const mutationObserver = new MutationObserver(function(mutations) {
+         mutations.forEach(function(mutation) {
+            if (mutation.addedNodes.length > 0) {
+               // loop through added nodes
+               for (let i = 0; i < mutation.addedNodes.length; i++) {
+                  const node = mutation.addedNodes[i];
+                  if (node.id === 'webresources-content') {
+                     const state = window.GlpiPluginWebResources.getDashboardState();
+                     window.GlpiPluginWebResources.refreshDashboard(state.context, state.view_mode);
+                     mutationObserver.disconnect();
+                  }
+               }
+            }
+         });
+      });
+      mutationObserver.observe(document.body, {
+         childList: true,
+         subtree: true
+      });
+   }
+});

--- a/setup.php
+++ b/setup.php
@@ -46,6 +46,11 @@ function plugin_init_webresources()
       ];
       $PLUGIN_HOOKS['pre_item_purge']['webresources'] = 'plugin_webresources_preItemPurge';
       $PLUGIN_HOOKS['add_css']['webresources'][] = 'css/webresources.scss';
+
+      // If current URL contains 'front/central.php' or 'webresources/front/dashboard.php', include the dashboard.js script
+      if (strpos($_SERVER['REQUEST_URI'], 'front/central.php') !== false || strpos($_SERVER['REQUEST_URI'], 'webresources/front/dashboard.php') !== false) {
+         $PLUGIN_HOOKS['add_javascript']['webresources'][] = 'js/dashboard.js';
+      }
    }
 }
 


### PR DESCRIPTION
Add ability to switch between a grid and list view for resources.

This also adds better state tracking so the dashboard will load its previous context and view mode after a restart.
The regular dashboard will use URL parameters, while the dashboard on the Central page (home page) will use localStorage to track the state.

Most of the JS was moved into a script file instead of being inline.

The initial dashboard content loading is now done asynchronously. This should make pages feel more responsive and greatly simplified the script logic.